### PR TITLE
terraform: fix aws-vpc module to version "~> v1.0"

### DIFF
--- a/terraform/module-infrastructure/vpc_infra.tf
+++ b/terraform/module-infrastructure/vpc_infra.tf
@@ -44,7 +44,8 @@ locals {
 #
 
 module "infra_vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> v1.0"
 
   name = "${var.customer}-infra${var.suffix}"
   azs  = "${var.zones}"

--- a/terraform/module-infrastructure/vpc_prod.tf
+++ b/terraform/module-infrastructure/vpc_prod.tf
@@ -37,7 +37,8 @@ variable "prod_redshift_subnets" {
 #
 
 module "prod_vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> v1.0"
 
   name = "${var.customer}-prod${var.suffix}"
   azs  = "${var.zones}"

--- a/terraform/module-infrastructure/vpc_staging.tf
+++ b/terraform/module-infrastructure/vpc_staging.tf
@@ -41,7 +41,8 @@ locals {
 # Create VPC
 #
 module "staging_vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> v1.0"
 
   name = "${var.customer}-staging${var.suffix}"
   azs  = "${var.zones}"


### PR DESCRIPTION
```
The `storage` parameter is deprecated. Please migrate to using built-in Terraform backends as described here: https://github.com/ljfranklin/terraform-resource#backend-migration.

2019/06/17 16:35:58 terraform init command failed.
Error: exit status 1
Output: Initializing modules...
- module.infrastructure
  Getting source "module-infrastructure"
- module.infrastructure.infra_vpc
  Found version 2.7.0 of terraform-aws-modules/vpc/aws on registry.terraform.io
  Getting source "terraform-aws-modules/vpc/aws"
Error downloading modules: Error loading modules: module infra_vpc: Error parsing .terraform/modules/c7754049851005d71d05529bacf9d67e/terraform-aws-modules-terraform-aws-vpc-271b6a7/main.tf: At 2:23: Unknown token: 2:23 IDENT max
```

https://cycloid-io.slack.com/archives/C09LPKN21/p1560765414171900