### PR TITLE
terraform: remove admin-users that can't be determined correctly during a terraform plan

### DIFF
--- a/terraform/infrastructure.tf.sample
+++ b/terraform/infrastructure.tf.sample
@@ -34,7 +34,7 @@ module "infrastructure" {
 
   #. infra_cidr: 10.0.0.0/16
   #+ The CIDR of the infra VPC
-  infra_cidr            = "10.0.0.0/16"
+  infra_cidr = "10.0.0.0/16"
 
   #. infra_private_subnets (optional, list): ["10.0.0.0/24", "10.0.2.0/24", "10.0.4.0/24"]
   #+ The private subnets for the infra VPC
@@ -42,7 +42,7 @@ module "infrastructure" {
 
   #. infra_public_subnets (optional, list): ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
   #+ The public subnets for the infra VPC
-  infra_public_subnets  = ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
+  infra_public_subnets = ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
 
   #. infra_associate_vpc_to_all_private_zones (optional, bool): false
   #+ Should be true if you want to associate the infra VPC to staging and prod privates zones.
@@ -54,19 +54,19 @@ module "infrastructure" {
 
   #. staging_cidr: 10.1.0.0/16
   #+ The CIDR of the staging VPC
-  staging_cidr                = "10.1.0.0/16"
+  staging_cidr = "10.1.0.0/16"
 
   #. staging_private_subnets (optional, list): ["10.1.0.0/24", "10.1.2.0/24", "10.1.4.0/24"]
   #+ The private subnets for the staging VPC
-  staging_private_subnets     = ["10.1.0.0/24", "10.1.4.0/24", "10.1.8.0/24"]
+  staging_private_subnets = ["10.1.0.0/24", "10.1.4.0/24", "10.1.8.0/24"]
 
   #. staging_public_subnets (optional, list): ["10.1.1.0/24", "10.1.3.0/24", "10.1.5.0/24"]
   #+ The public subnets for the staging VPC
-  staging_public_subnets      = ["10.1.1.0/24", "10.1.5.0/24", "10.1.9.0/24"]
+  staging_public_subnets = ["10.1.1.0/24", "10.1.5.0/24", "10.1.9.0/24"]
 
   #. staging_rds_subnets (optional, list): ["10.1.2.0/24", "10.1.6.0/24", "10.1.10.0/24"]
   #+ The RDS subnets for the staging VPC
-  staging_rds_subnets         = ["10.1.2.0/24", "10.1.6.0/24", "10.1.10.0/24"]
+  staging_rds_subnets = ["10.1.2.0/24", "10.1.6.0/24", "10.1.10.0/24"]
 
   #. staging_elasticache_subnets (optional, list): []
   #+ The Elasticache subnets for the staging VPC

--- a/terraform/module-infrastructure/account_iam.tf
+++ b/terraform/module-infrastructure/account_iam.tf
@@ -1,7 +1,3 @@
-locals {
-  admin-users = compact(concat(aws_iam_user.infra.*.name, var.extra_admin_users))
-}
-
 resource "aws_iam_user" "infra" {
   count = var.create_infra_user ? 1 : 0
 
@@ -14,16 +10,21 @@ resource "aws_iam_access_key" "infra" {
   user  = aws_iam_user.infra[0].name
 }
 
-resource "aws_iam_role_policy_attachment" "infra_administrator_access_role" {
-  count = var.create_infra_user ? 1 : 0
+resource "aws_iam_user_policy_attachment" "infra_administrator_access_user" {
+  count      = var.create_infra_user ? 1 : 0
+  user       = aws_iam_user.infra[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
 
+resource "aws_iam_role_policy_attachment" "infra_administrator_access_role" {
+  count      = var.create_infra_user ? 1 : 0
   role       = "admin"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
-resource "aws_iam_user_policy_attachment" "infra_administrator_access_user" {
-  count      = length(local.admin-users)
-  user       = element(local.admin-users, count.index)
+resource "aws_iam_user_policy_attachment" "infra_administrator_access_extra_users" {
+  count      = length(var.extra_admin_users)
+  user       = element(var.extra_admin_users, count.index)
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 

--- a/terraform/module-infrastructure/outputs.tf
+++ b/terraform/module-infrastructure/outputs.tf
@@ -15,7 +15,7 @@ output "iam_ses_smtp_user_key" {
 }
 
 output "iam_ses_smtp_user_secret" {
-  value = aws_iam_access_key.ses_smtp_user.ses_smtp_password
+  value = aws_iam_access_key.ses_smtp_user.ses_smtp_password_v4
 }
 
 output "deployment_bucket_name" {


### PR DESCRIPTION
Error:
```
Error: Invalid count argument
  on module-infrastructure/account_iam.tf line 25, in resource "aws_iam_user_policy_attachment" "infra_administrator_access_user":
  25:   count      = length(local.admin-users)

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```