### PR TITLE
Added `dev` environment

### DIFF
--- a/.ci/terraform/infrastructure.tf
+++ b/.ci/terraform/infrastructure.tf
@@ -45,8 +45,31 @@ module "infrastructure" {
   infra_public_subnets  = ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
 
   #. infra_associate_vpc_to_all_private_zones (optional, bool): false
-  #+ Should be true if you want to associate the infra VPC to staging and prod privates zones.
+  #+ Should be true if you want to associate the infra VPC to dev, staging and prod privates zones.
   #infra_associate_vpc_to_all_private_zones = false
+
+  #
+  # dev VPC
+  #
+
+  #. dev_cidr: 10.1.0.0/16
+  #+ The CIDR of the dev VPC
+  dev_cidr                = "10.3.0.0/16"
+
+  #. dev_private_subnets (optional, list): ["10.3.0.0/24", "10.3.2.0/24", "10.3.4.0/24"]
+  #+ The private subnets for the dev VPC
+  dev_private_subnets     = ["10.3.0.0/24", "10.3.4.0/24", "10.1.8.0/24"]
+
+  #. dev_public_subnets (optional, list): ["10.3.1.0/24", "10.3.3.0/24", "10.3.5.0/24"]
+  #+ The public subnets for the dev VPC
+  dev_public_subnets      = ["10.3.1.0/24", "10.3.5.0/24", "10.3.9.0/24"]
+
+  #. dev_rds_subnets (optional, list): ["10.3.2.0/24", "10.3.6.0/24", "10.3.10.0/24"]
+  #+ The RDS subnets for the dev VPC
+  dev_rds_subnets         = ["10.3.2.0/24", "10.3.6.0/24", "10.3.10.0/24"]
+
+  #. dev_elasticache_subnets (optional, list): []
+  #+ The Elasticache subnets for the dev VPC
 
   #
   # staging VPC

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ In order to run this task, couple elements are required within the infrastructur
 |`enable_dynamodb_endpoint`|Should be true if you want to provision a DynamoDB endpoint to the VPC|`bool`|`false`|`False`|
 |`enable_s3_endpoint`|Should be true if you want to provision an S3 endpoint to the VPC|`bool`|`false`|`False`|
 |`extra_admin_users`|List of users to give the administrator access role to|`list`|`[]`|`False`|
-|`infra_associate_vpc_to_all_private_zones`|Should be true if you want to associate the infra VPC to staging and prod privates zones.|`bool`|`false`|`False`|
+|`infra_associate_vpc_to_all_private_zones`|Should be true if you want to associate the infra VPC to dev, staging and prod privates zones.|`bool`|`false`|`False`|
 |`infra_cidr`|The CIDR of the infra VPC|`-`|`10.0.0.0/16`|`False`|
 |`infra_private_subnets`|The private subnets for the infra VPC|`list`|`["10.0.0.0/24", "10.0.2.0/24", "10.0.4.0/24"]`|`False`|
 |`infra_public_subnets`|The public subnets for the infra VPC|`list`|`["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]`|`False`|
@@ -97,6 +97,11 @@ In order to run this task, couple elements are required within the infrastructur
 |`staging_private_subnets`|The private subnets for the staging VPC|`list`|`["10.1.0.0/24", "10.1.2.0/24", "10.1.4.0/24"]`|`False`|
 |`staging_public_subnets`|The public subnets for the staging VPC|`list`|`["10.1.1.0/24", "10.1.3.0/24", "10.1.5.0/24"]`|`False`|
 |`staging_rds_subnets`|The RDS subnets for the staging VPC|`list`|`["10.1.2.0/24", "10.1.6.0/24", "10.1.10.0/24"]`|`False`|
+|`dev_cidr`|The CIDR of the dev VPC|`-`|`10.3.0.0/16`|`False`|
+|`dev_elasticache_subnets`|The Elasticache subnets for the dev VPC|`list`|`[]`|`False`|
+|`dev_private_subnets`|The private subnets for the dev VPC|`list`|`["10.3.0.0/24", "10.3.2.0/24", "10.3.4.0/24"]`|`False`|
+|`dev_public_subnets`|The public subnets for the dev VPC|`list`|`["10.3.1.0/24", "10.3.3.0/24", "10.3.5.0/24"]`|`False`|
+|`dev_rds_subnets`|The RDS subnets for the dev VPC|`list`|`["10.3.2.0/24", "10.3.6.0/24", "10.3.10.0/24"]`|`False`|
 |`zones`|The availability zones you want to use|`-`|`[]`|`False`|
 
 
@@ -144,7 +149,19 @@ In order to run this task, couple elements are required within the infrastructur
 | staging_rds_subnets | The RDS subnets for the staging VPC |
 | staging_redshift_subnet_group | The Redshift subnet group for the staging VPC |
 | staging_redshift_subnets | The redshift subnets for the staging VPC |
-| staging_vpc_id | The VPC ID for the staging VPC |
+| dev_vpc_id | The VPC ID for the dev VPC |
+| dev_bastion_sg_allow | security group ID tp allow SSH traffic from the bastion to the dev instances |
+| dev_elasticache_subnet_group | The elasticache subnet group for the dev VPC |
+| dev_elasticache_subnets | The elasticache subnets for the dev VPC |
+| dev_private_subnets | The private subnets for the dev VPC |
+| dev_private_zone_id | Route53 private zone ID for the dev VPC |
+| dev_public_subnets | The public subnets for the dev VPC |
+| dev_rds_parameters-mysql57 | RDS db parameters ID for the dev VPC |
+| dev_rds_subnet_group | The RDS subnet group for the dev VPC |
+| dev_rds_subnets | The RDS subnets for the dev VPC |
+| dev_redshift_subnet_group | The Redshift subnet group for the dev VPC |
+| dev_redshift_subnets | The redshift subnets for the dev VPC |
+| dev_vpc_id | The VPC ID for the dev VPC |
 | zones | AWS availability zones used |
 
 

--- a/terraform/infrastructure.tf.sample
+++ b/terraform/infrastructure.tf.sample
@@ -45,8 +45,31 @@ module "infrastructure" {
   infra_public_subnets = ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
 
   #. infra_associate_vpc_to_all_private_zones (optional, bool): false
-  #+ Should be true if you want to associate the infra VPC to staging and prod privates zones.
+  #+ Should be true if you want to associate the infra VPC to dev, staging and prod privates zones.
   #infra_associate_vpc_to_all_private_zones = false
+
+  #
+  # dev VPC
+  #
+
+  #. dev_cidr: 10.3.0.0/16
+  #+ The CIDR of the dev VPC
+  dev_cidr = "10.3.0.0/16"
+
+  #. dev_private_subnets (optional, list): ["10.3.0.0/24", "10.3.2.0/24", "10.3.4.0/24"]
+  #+ The private subnets for the dev VPC
+  dev_private_subnets = ["10.3.0.0/24", "10.3.4.0/24", "10.3.8.0/24"]
+
+  #. dev_public_subnets (optional, list): ["10.3.1.0/24", "10.3.3.0/24", "10.3.5.0/24"]
+  #+ The public subnets for the dev VPC
+  dev_public_subnets = ["10.3.1.0/24", "10.3.5.0/24", "10.3.9.0/24"]
+
+  #. dev_rds_subnets (optional, list): ["10.3.2.0/24", "10.3.6.0/24", "10.3.10.0/24"]
+  #+ The RDS subnets for the dev VPC
+  dev_rds_subnets = ["10.3.2.0/24", "10.3.6.0/24", "10.3.10.0/24"]
+
+  #. dev_elasticache_subnets (optional, list): []
+  #+ The Elasticache subnets for the dev VPC
 
   #
   # staging VPC

--- a/terraform/module-infrastructure/vpc_dev.tf
+++ b/terraform/module-infrastructure/vpc_dev.tf
@@ -1,0 +1,295 @@
+#
+# Variables
+#
+variable "dev_cidr" {
+  description = "The CIDR of the dev VPC"
+  default     = "10.3.0.0/16"
+}
+
+variable "dev_private_subnets" {
+  description = "The private subnets for the dev VPC"
+  default     = ["10.3.0.0/24", "10.3.2.0/24", "10.3.4.0/24"]
+}
+
+variable "dev_public_subnets" {
+  description = "The public subnets for the dev VPC"
+  default     = ["10.3.1.0/24", "10.3.3.0/24", "10.3.5.0/24"]
+}
+
+variable "dev_elasticache_subnets" {
+  description = "The Elasticache subnets for the dev VPC"
+  default     = []
+}
+
+variable "dev_rds_subnets" {
+  description = "The RDS subnets for the dev VPC"
+  default     = ["10.3.2.0/24", "10.3.6.0/24", "10.3.10.0/24"]
+}
+
+variable "dev_redshift_subnets" {
+  description = "The Redshift subnets for the dev VPC"
+  default     = []
+}
+
+# Fix for value of count cannot be computed, generating the count as the same way as amazon vpc module do : https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/main.tf#L5
+locals {
+  dev_max_subnet_length = max(
+    length(var.dev_private_subnets),
+    length(var.dev_elasticache_subnets),
+    length(var.dev_rds_subnets),
+    length(var.dev_redshift_subnets),
+  )
+  dev_nat_gateway_count = var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(local.aws_availability_zones) : local.dev_max_subnet_length
+}
+
+#
+# Create VPC
+#
+module "dev_vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> v2.17"
+
+  name = "${var.customer}-dev${var.suffix}"
+  azs  = local.aws_availability_zones
+  cidr = var.dev_cidr
+
+  private_subnets     = var.dev_private_subnets
+  enable_nat_gateway  = true
+  single_nat_gateway  = true
+  public_subnets      = var.dev_public_subnets
+  elasticache_subnets = var.dev_elasticache_subnets
+  database_subnets    = var.dev_rds_subnets
+  redshift_subnets    = var.dev_redshift_subnets
+
+  enable_dns_hostnames     = true
+  enable_dhcp_options      = true
+  dhcp_options_domain_name = "${var.customer}.dev"
+
+  enable_s3_endpoint       = var.enable_s3_endpoint
+  enable_dynamodb_endpoint = var.enable_dynamodb_endpoint
+
+  tags = local.merged_tags
+}
+
+resource "aws_vpc_peering_connection" "infra_dev" {
+  peer_vpc_id = module.infra_vpc.vpc_id
+  vpc_id      = module.dev_vpc.vpc_id
+  auto_accept = true
+
+  tags = merge(local.merged_tags, {
+    Name       = "VPC Peering between infra and dev"
+  })
+}
+
+resource "aws_route" "infra_dev_public" {
+  #count = "${length(module.infra_vpc.public_route_table_ids)}"
+  count = var.create_vpc && length(var.infra_public_subnets) > 0 ? 1 : 0
+
+  route_table_id            = element(module.infra_vpc.public_route_table_ids, count.index)
+  destination_cidr_block    = var.dev_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.infra_dev.id
+}
+
+resource "aws_route" "infra_dev_private" {
+  #count = "${length(module.infra_vpc.private_route_table_ids)}"
+  count = var.create_vpc && local.infra_max_subnet_length > 0 ? local.infra_nat_gateway_count : 0
+
+  route_table_id            = element(module.infra_vpc.private_route_table_ids, count.index)
+  destination_cidr_block    = var.dev_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.infra_dev.id
+}
+
+resource "aws_route" "dev_infra_public" {
+  #count = "${length(module.infra_vpc.public_route_table_ids)}"
+  count = var.create_vpc && length(var.dev_public_subnets) > 0 ? 1 : 0
+
+  route_table_id            = element(module.dev_vpc.public_route_table_ids, count.index)
+  destination_cidr_block    = var.infra_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.infra_dev.id
+}
+
+resource "aws_route" "dev_infra_private" {
+  #count = "${length(module.infra_vpc.private_route_table_ids)}"
+  count = var.create_vpc && local.dev_max_subnet_length > 0 ? local.dev_nat_gateway_count : 0
+
+  route_table_id            = element(module.dev_vpc.private_route_table_ids, count.index)
+  destination_cidr_block    = var.infra_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.infra_dev.id
+}
+
+resource "aws_security_group" "allow_bastion_dev" {
+  count = var.bastion_count > 0 ? 1 : 0
+
+  name        = "allow-bastion-dev${var.suffix}"
+  description = "Allow SSH traffic from the bastion to the dev env"
+  vpc_id      = module.dev_vpc.vpc_id
+
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion[0].id]
+    self            = false
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.merged_tags, {
+    Name       = "allow-bastion-dev${var.suffix}"
+  })
+}
+
+# Create route53 zones
+## Private zone
+resource "aws_route53_zone" "dev_private" {
+  name = "${var.customer}.dev"
+
+  vpc {
+    vpc_id = module.dev_vpc.vpc_id
+  }
+
+  tags = local.merged_tags
+
+  lifecycle {
+    ignore_changes = [vpc]
+  }
+}
+
+resource "aws_route53_zone_association" "dev_private_infra" {
+  zone_id = aws_route53_zone.dev_private.zone_id
+  vpc_id  = module.infra_vpc.vpc_id
+  count   = var.infra_associate_vpc_to_all_private_zones ? 1 : 0
+}
+
+#
+# mysql
+#
+
+resource "aws_db_parameter_group" "dev_rds-optimized-mysql57" {
+  name        = "rds-optimized-mysql-${var.customer}-dev"
+  family      = "mysql5.7"
+  description = "Cycloid optimizations for ${var.customer}-dev"
+
+  parameter {
+    name  = "log_bin_trust_function_creators"
+    value = "1"
+  }
+
+  parameter {
+    name         = "query_cache_type"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "innodb_buffer_pool_size"
+    value        = "{DBInstanceClassMemory*2/3}"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_allowed_packet"
+    value        = "67108864"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "query_cache_size"
+    value        = "67108864"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "tmp_table_size"
+    value        = "134217728"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_heap_table_size"
+    value        = "134217728"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "slow_query_log"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_output"
+    value = "file"
+  }
+}
+
+#
+# output
+#
+
+// Expose the mysql rds parameters
+output "dev_rds_parameters-mysql57" {
+  value = aws_db_parameter_group.dev_rds-optimized-mysql57.id
+}
+
+// Expose the private zone id
+output "dev_private_zone_id" {
+  value = aws_route53_zone.dev_private.zone_id
+}
+
+output "dev_bastion_sg_allow" {
+  value = element(aws_security_group.allow_bastion_dev.*.id, 0)
+}
+
+output "dev_vpc_id" {
+  value = module.dev_vpc.vpc_id
+}
+
+output "dev_vpc_cidr" {
+  value = var.dev_cidr
+}
+
+output "dev_public_route_table_ids" {
+  value = module.dev_vpc.public_route_table_ids
+}
+
+output "dev_private_route_table_ids" {
+  value = module.dev_vpc.private_route_table_ids
+}
+
+output "dev_private_subnets" {
+  value = module.dev_vpc.private_subnets
+}
+
+output "dev_public_subnets" {
+  value = module.dev_vpc.public_subnets
+}
+
+output "dev_elasticache_subnets" {
+  value = module.dev_vpc.elasticache_subnets
+}
+
+output "dev_elasticache_subnet_group" {
+  value = module.dev_vpc.elasticache_subnet_group
+}
+
+output "dev_rds_subnets" {
+  value = module.dev_vpc.database_subnets
+}
+
+output "dev_rds_subnet_group" {
+  value = module.dev_vpc.database_subnet_group
+}
+
+output "dev_redshift_subnets" {
+  value = module.dev_vpc.redshift_subnets
+}
+
+output "dev_redshift_subnet_group" {
+  value = module.dev_vpc.redshift_subnet_group
+}
+

--- a/terraform/module-infrastructure/vpc_infra.tf
+++ b/terraform/module-infrastructure/vpc_infra.tf
@@ -16,9 +16,9 @@ variable "infra_public_subnets" {
   default     = ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
 }
 
-# Allow the infra VPC to access prod and staging privates zones.
+# Allow the infra VPC to access prod, staging and dev privates zones.
 variable "infra_associate_vpc_to_all_private_zones" {
-  description = "Should be true if you want to associate the infra VPC to staging and prod privates zones."
+  description = "Should be true if you want to associate the infra VPC to dev, staging and prod privates zones."
   default     = false
 }
 

--- a/terraform/outputs_dev.tf
+++ b/terraform/outputs_dev.tf
@@ -1,0 +1,75 @@
+output "dev_bastion_sg_allow" {
+  description = "security group ID tp allow SSH traffic from the bastion to the dev instances"
+  value       = module.infrastructure.dev_bastion_sg_allow
+}
+
+output "dev_vpc_id" {
+  description = "The VPC ID for the dev VPC"
+  value       = module.infrastructure.dev_vpc_id
+}
+
+output "dev_vpc_cidr" {
+  description = "The CIDR for the dev VPC"
+  value       = module.infrastructure.dev_vpc_cidr
+}
+
+output "dev_public_route_table_ids" {
+  description = "The public route table IDs for the dev VPC"
+  value       = module.infrastructure.dev_public_route_table_ids
+}
+
+output "dev_private_route_table_ids" {
+  description = "The private route table IDs for the dev VPC"
+  value       = module.infrastructure.dev_private_route_table_ids
+}
+
+output "dev_private_subnets" {
+  description = "The private subnets for the dev VPC"
+  value       = module.infrastructure.dev_private_subnets
+}
+
+output "dev_public_subnets" {
+  description = "The public subnets for the dev VPC"
+  value       = module.infrastructure.dev_public_subnets
+}
+
+output "dev_elasticache_subnets" {
+  description = "The elasticache subnets for the dev VPC"
+  value       = module.infrastructure.dev_elasticache_subnets
+}
+
+output "dev_elasticache_subnet_group" {
+  description = "The elasticache subnet group for the dev VPC"
+  value       = module.infrastructure.dev_elasticache_subnet_group
+}
+
+output "dev_rds_subnets" {
+  description = "The RDS subnets for the dev VPC"
+  value       = module.infrastructure.dev_rds_subnets
+}
+
+output "dev_rds_subnet_group" {
+  description = "The RDS subnet group for the dev VPC"
+  value       = module.infrastructure.dev_rds_subnet_group
+}
+
+output "dev_redshift_subnets" {
+  description = "The redshift subnets for the dev VPC"
+  value       = module.infrastructure.dev_redshift_subnets
+}
+
+output "dev_redshift_subnet_group" {
+  description = "The Redshift subnet group for the dev VPC"
+  value       = module.infrastructure.dev_redshift_subnet_group
+}
+
+output "dev_private_zone_id" {
+  description = "Route53 private zone ID for the dev VPC"
+  value       = module.infrastructure.dev_private_zone_id
+}
+
+output "dev_rds_parameters-mysql57" {
+  description = "RDS db parameters ID for the dev VPC"
+  value       = module.infrastructure.dev_rds_parameters-mysql57
+}
+


### PR DESCRIPTION
Hi,

This PR introduce an extra environment called `dev`. This environment is meant to be used as an integration environment to deploy and test features during development cycles. 

The `staging` environement is not sufficient to fulfill this job since conceptually, I think that the `staging` environment is meant to be a representation of the "production environment" and shall not be used for development testing but only for "deployment testing". 

Also, deploying features on the `staging` environment during a long development cycle blocks/complicates testing of bugfixes and hotfixes because the database on this environment will be on a different state than the one in production.
It would be possible to trigger some database resets for staging on some circumstances but in my opinion, this would create unnecessary complexity for this environment and/or that would be a pain for QA guys.

This PR is a follow-up of the ticket #1367 opened on your side.

Let me know what you think, what is missing/could be added, and what are the next steps regarding integration of this new environment.